### PR TITLE
Danny hilbertspace update

### DIFF
--- a/docs/source/guide/ipynb/hilbertspace.ipynb
+++ b/docs/source/guide/ipynb/hilbertspace.ipynb
@@ -111,7 +111,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "704241b89c874f64a3f0d22156e58f40",
+       "model_id": "08807093e10b4b1d978259213a90bfed",
        "version_major": 2,
        "version_minor": 0
       },
@@ -125,7 +125,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3e6cadf071a548e683ced7feb29da046",
+       "model_id": "a41af57bf5b845978331aa11824c3ccd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -185,7 +185,7 @@
       "HilbertSpace:  subsystems\n",
       "-------------------------\n",
       "\n",
-      "Transmon------------|\n",
+      "Transmon------------| [Transmon_1]\n",
       "                    | EJ: 40.0\n",
       "                    | EC: 0.2\n",
       "                    | ng: 0.3\n",
@@ -195,7 +195,7 @@
       "                    | dim: 81\n",
       "\n",
       "\n",
-      "Transmon------------|\n",
+      "Transmon------------| [Transmon_2]\n",
       "                    | EJ: 15.0\n",
       "                    | EC: 0.15\n",
       "                    | ng: 0.0\n",
@@ -205,7 +205,7 @@
       "                    | dim: 61\n",
       "\n",
       "\n",
-      "Oscillator----------|\n",
+      "Oscillator----------| [Oscillator_1]\n",
       "                    | E_osc: 4.5\n",
       "                    | l_osc: None\n",
       "                    | truncated_dim: 4\n",
@@ -627,7 +627,8 @@
     {
      "data": {
       "text/plain": [
-       "array([-36.05064983, -28.25601136, -20.67410141, -13.31487799])"
+       "NamedSlotsNdarray([[-36.05064983, -28.25601136, -20.67410141,\n",
+       "                    -13.31487799]])"
       ]
      },
      "execution_count": 12,
@@ -636,7 +637,8 @@
     }
    ],
    "source": [
-    "hilbertspace.lookup.bare_eigenenergies(tmon1)"
+    "tmon1_idx = hilbertspace.get_subsys_index(tmon1)\n",
+    "hilbertspace[\"bare_evals\"][tmon1_idx]"
    ]
   },
   {
@@ -671,7 +673,7 @@
     }
    ],
    "source": [
-    "hilbertspace.lookup.bare_index(8)"
+    "hilbertspace.bare_index(8)"
    ]
   },
   {
@@ -709,7 +711,7 @@
     }
    ],
    "source": [
-    "hilbertspace.lookup.dressed_index((2, 1, 0))"
+    "hilbertspace.dressed_index((2, 1, 0))"
    ]
   },
   {
@@ -735,7 +737,7 @@
     {
      "data": {
       "text/plain": [
-       "-36.56694138527015"
+       "-36.56694138527016"
       ]
      },
      "execution_count": 15,
@@ -744,7 +746,7 @@
     }
    ],
    "source": [
-    "hilbertspace.lookup.energy_dressed_index(10)"
+    "hilbertspace.energy_by_dressed_index(10)"
    ]
   },
   {
@@ -765,21 +767,45 @@
     "\n",
     "$H = H_1\\otimes\\mathbb{I}\\otimes \\mathbb{I} + \\mathbb{I}\\otimes H_2\\otimes \\mathbb{I} + \\mathbb{I}\\otimes\\mathbb{I}\\otimes H_3$\n",
     "\n",
-    "In most places of the `HilbertSpace` class, scqubits manages this \"identity wrapping\" automatically. In some use cases, it may become necessary to invoke this functionality manually. For that purpose, scqubits implements the helper routine `identity_wrap`. For instance, the term $\\mathbb{I}\\otimes H_2\\otimes \\mathbb{I}$ would be generated via:\n",
-    "\n"
+    "In most places of the `HilbertSpace` class, scqubits manages this \"identity wrapping\" automatically. In some use cases, it may become necessary to invoke this functionality manually. For that purpose, scqubits implements the helper routine `identity_wrap`. For instance, the term $\\mathbb{I}\\otimes H_2\\otimes \\mathbb{I}$ would be generated via the pseudocode `scq.identity_wrap(H2, subsystem2, [subsystem1, subsystem2, subsystem3])`.\n",
+    "\n",
+    "In the context of the above example of two transmons coupled to an oscillator, the identity-wrapped charge operator of the second transmon is generated via"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[4, 4, 4], [4, 4, 4]], shape = (64, 64), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}0.0 & 0.0 & 0.0 & 0.0 & 1.305 & \\cdots & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & \\cdots & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & \\cdots & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & \\cdots & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\1.305 & 0.0 & 0.0 & 0.0 & 0.0 & \\cdots & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\\\vdots & \\vdots & \\vdots & \\vdots & \\vdots & \\ddots & \\vdots & \\vdots & \\vdots & \\vdots & \\vdots\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & \\cdots & 0.0 & 0.0 & 0.0 & 0.0 & -2.162\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & \\cdots & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & \\cdots & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & \\cdots & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & \\cdots & -2.162 & 0.0 & 0.0 & 0.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[4, 4, 4], [4, 4, 4]], shape = (64, 64), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[0. 0. 0. ... 0. 0. 0.]\n",
+       " [0. 0. 0. ... 0. 0. 0.]\n",
+       " [0. 0. 0. ... 0. 0. 0.]\n",
+       " ...\n",
+       " [0. 0. 0. ... 0. 0. 0.]\n",
+       " [0. 0. 0. ... 0. 0. 0.]\n",
+       " [0. 0. 0. ... 0. 0. 0.]]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "scq.identity_wrap(H2, subsystem2, [subsystem1, subsystem2, subsystem3])"
+    "scq.identity_wrap(tmon2.n_operator(), tmon2, hilbertspace.subsystem_list)"
    ]
   },
   {
@@ -816,13 +842,168 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
+   "source": [
+    "## Helper function:  subsystem operator in dressed basis\n",
+    "\n",
+    "Oftentimes for qutip simulations, the most natural basis to use is the dressed basis of the full system. This way, any transitions between basis states are the result of additional (usually time-dependent) drives. These drives are often given in terms of an operator of one of the subsystems. We would like to transform that operator into the dressed basis. This requires two transformations: the first is from the \"native\" basis of the subsystem (for instance the charge basis for the transmon) into its bare eigenbasis, which is the basis used in `HilbertSpace`. The second is from the bare eigenbasis into the dressed eigenbasis. \n",
+    "\n",
+    "For instance, the charge operator of the first transmon system may be expressed in the dressed eigenbasis as"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[4, 4, 4], [4, 4, 4]], shape = (64, 64), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}0.301 & -0.039 & -0.085 & -8.168\\times10^{-06} & 1.558 & \\cdots & -1.122\\times10^{-10} & 1.605\\times10^{-10} & -9.217\\times10^{-11} & 7.380\\times10^{-11} & -1.485\\times10^{-10}\\\\-0.039 & 0.301 & -9.554\\times10^{-08} & 0.047 & 2.549\\times10^{-07} & \\cdots & 1.951\\times10^{-08} & 8.473\\times10^{-09} & 1.147\\times10^{-08} & -1.311\\times10^{-08} & 2.163\\times10^{-10}\\\\-0.085 & -9.554\\times10^{-08} & 0.301 & -0.002 & 1.847\\times10^{-08} & \\cdots & 2.048\\times10^{-08} & 2.181\\times10^{-08} & 2.198\\times10^{-08} & -2.874\\times10^{-08} & 2.137\\times10^{-11}\\\\-8.168\\times10^{-06} & 0.047 & -0.002 & 0.301 & 3.679\\times10^{-07} & \\cdots & 6.351\\times10^{-08} & 2.604\\times10^{-06} & 2.402\\times10^{-08} & -1.360\\times10^{-08} & 2.820\\times10^{-08}\\\\1.558 & 2.549\\times10^{-07} & 1.847\\times10^{-08} & 3.679\\times10^{-07} & 0.301 & \\cdots & -1.520\\times10^{-10} & -5.187\\times10^{-09} & -5.495\\times10^{-09} & 9.614\\times10^{-09} & -7.209\\times10^{-11}\\\\\\vdots & \\vdots & \\vdots & \\vdots & \\vdots & \\ddots & \\vdots & \\vdots & \\vdots & \\vdots & \\vdots\\\\-1.122\\times10^{-10} & 1.951\\times10^{-08} & 2.048\\times10^{-08} & 6.351\\times10^{-08} & -1.520\\times10^{-10} & \\cdots & 0.298 & 0.006 & -7.660\\times10^{-05} & -0.002 & -2.577\\\\1.605\\times10^{-10} & 8.473\\times10^{-09} & 2.181\\times10^{-08} & 2.604\\times10^{-06} & -5.187\\times10^{-09} & \\cdots & 0.006 & 0.302 & 0.083 & -0.277 & 0.021\\\\-9.217\\times10^{-11} & 1.147\\times10^{-08} & 2.198\\times10^{-08} & 2.402\\times10^{-08} & -5.495\\times10^{-09} & \\cdots & -7.660\\times10^{-05} & 0.083 & 0.302 & -0.006 & -0.461\\\\7.380\\times10^{-11} & -1.311\\times10^{-08} & -2.874\\times10^{-08} & -1.360\\times10^{-08} & 9.614\\times10^{-09} & \\cdots & -0.002 & -0.277 & -0.006 & 0.303 & -0.248\\\\-1.485\\times10^{-10} & 2.163\\times10^{-10} & 2.137\\times10^{-11} & 2.820\\times10^{-08} & -7.209\\times10^{-11} & \\cdots & -2.577 & 0.021 & -0.461 & -0.248 & 0.308\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[4, 4, 4], [4, 4, 4]], shape = (64, 64), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 3.00848255e-01 -3.94988892e-02 -8.51789422e-02 ... -9.21708710e-11\n",
+       "   7.38031846e-11 -1.48511179e-10]\n",
+       " [-3.94988892e-02  3.00848175e-01 -9.55399455e-08 ...  1.14676353e-08\n",
+       "  -1.31056971e-08  2.16270693e-10]\n",
+       " [-8.51789422e-02 -9.55399455e-08  3.00848062e-01 ...  2.19795959e-08\n",
+       "  -2.87402598e-08  2.13690326e-11]\n",
+       " ...\n",
+       " [-9.21708710e-11  1.14676353e-08  2.19795959e-08 ...  3.01845306e-01\n",
+       "  -6.18505106e-03 -4.60901874e-01]\n",
+       " [ 7.38031846e-11 -1.31056971e-08 -2.87402598e-08 ... -6.18505106e-03\n",
+       "   3.02528544e-01 -2.48191443e-01]\n",
+       " [-1.48511179e-10  2.16270693e-10  2.13690326e-11 ... -4.60901874e-01\n",
+       "  -2.48191443e-01  3.08183200e-01]]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hilbertspace.op_in_dressed_eigenbasis(op=tmon1.n_operator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, the function may be called by supplying both a pair `(<operator as ndarray>,  <subsys>)`, as well as information on if the subsystem operator is already expressed in the bare eigenbasis. Examples of both cases (subsystem operator expressed in the native and bare eigenbasis) follow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[4, 4, 4], [4, 4, 4]], shape = (64, 64), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}0.301 & -0.039 & -0.085 & -8.168\\times10^{-06} & 1.558 & \\cdots & -1.122\\times10^{-10} & 1.605\\times10^{-10} & -9.217\\times10^{-11} & 7.380\\times10^{-11} & -1.485\\times10^{-10}\\\\-0.039 & 0.301 & -9.554\\times10^{-08} & 0.047 & 2.549\\times10^{-07} & \\cdots & 1.951\\times10^{-08} & 8.473\\times10^{-09} & 1.147\\times10^{-08} & -1.311\\times10^{-08} & 2.163\\times10^{-10}\\\\-0.085 & -9.554\\times10^{-08} & 0.301 & -0.002 & 1.847\\times10^{-08} & \\cdots & 2.048\\times10^{-08} & 2.181\\times10^{-08} & 2.198\\times10^{-08} & -2.874\\times10^{-08} & 2.137\\times10^{-11}\\\\-8.168\\times10^{-06} & 0.047 & -0.002 & 0.301 & 3.679\\times10^{-07} & \\cdots & 6.351\\times10^{-08} & 2.604\\times10^{-06} & 2.402\\times10^{-08} & -1.360\\times10^{-08} & 2.820\\times10^{-08}\\\\1.558 & 2.549\\times10^{-07} & 1.847\\times10^{-08} & 3.679\\times10^{-07} & 0.301 & \\cdots & -1.520\\times10^{-10} & -5.187\\times10^{-09} & -5.495\\times10^{-09} & 9.614\\times10^{-09} & -7.209\\times10^{-11}\\\\\\vdots & \\vdots & \\vdots & \\vdots & \\vdots & \\ddots & \\vdots & \\vdots & \\vdots & \\vdots & \\vdots\\\\-1.122\\times10^{-10} & 1.951\\times10^{-08} & 2.048\\times10^{-08} & 6.351\\times10^{-08} & -1.520\\times10^{-10} & \\cdots & 0.298 & 0.006 & -7.660\\times10^{-05} & -0.002 & -2.577\\\\1.605\\times10^{-10} & 8.473\\times10^{-09} & 2.181\\times10^{-08} & 2.604\\times10^{-06} & -5.187\\times10^{-09} & \\cdots & 0.006 & 0.302 & 0.083 & -0.277 & 0.021\\\\-9.217\\times10^{-11} & 1.147\\times10^{-08} & 2.198\\times10^{-08} & 2.402\\times10^{-08} & -5.495\\times10^{-09} & \\cdots & -7.660\\times10^{-05} & 0.083 & 0.302 & -0.006 & -0.461\\\\7.380\\times10^{-11} & -1.311\\times10^{-08} & -2.874\\times10^{-08} & -1.360\\times10^{-08} & 9.614\\times10^{-09} & \\cdots & -0.002 & -0.277 & -0.006 & 0.303 & -0.248\\\\-1.485\\times10^{-10} & 2.163\\times10^{-10} & 2.137\\times10^{-11} & 2.820\\times10^{-08} & -7.209\\times10^{-11} & \\cdots & -2.577 & 0.021 & -0.461 & -0.248 & 0.308\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[4, 4, 4], [4, 4, 4]], shape = (64, 64), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 3.00848255e-01 -3.94988892e-02 -8.51789422e-02 ... -9.21708710e-11\n",
+       "   7.38031846e-11 -1.48511179e-10]\n",
+       " [-3.94988892e-02  3.00848175e-01 -9.55399455e-08 ...  1.14676353e-08\n",
+       "  -1.31056971e-08  2.16270693e-10]\n",
+       " [-8.51789422e-02 -9.55399455e-08  3.00848062e-01 ...  2.19795959e-08\n",
+       "  -2.87402598e-08  2.13690326e-11]\n",
+       " ...\n",
+       " [-9.21708710e-11  1.14676353e-08  2.19795959e-08 ...  3.01845306e-01\n",
+       "  -6.18505106e-03 -4.60901874e-01]\n",
+       " [ 7.38031846e-11 -1.31056971e-08 -2.87402598e-08 ... -6.18505106e-03\n",
+       "   3.02528544e-01 -2.48191443e-01]\n",
+       " [-1.48511179e-10  2.16270693e-10  2.13690326e-11 ... -4.60901874e-01\n",
+       "  -2.48191443e-01  3.08183200e-01]]"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hilbertspace.op_in_dressed_eigenbasis(op=(tmon1.n_operator(), tmon1), op_in_bare_eigenbasis=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[4, 4, 4], [4, 4, 4]], shape = (64, 64), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}0.301 & -0.039 & -0.085 & -8.168\\times10^{-06} & 1.558 & \\cdots & -1.122\\times10^{-10} & 1.605\\times10^{-10} & -9.217\\times10^{-11} & 7.380\\times10^{-11} & -1.485\\times10^{-10}\\\\-0.039 & 0.301 & -9.554\\times10^{-08} & 0.047 & 2.549\\times10^{-07} & \\cdots & 1.951\\times10^{-08} & 8.473\\times10^{-09} & 1.147\\times10^{-08} & -1.311\\times10^{-08} & 2.163\\times10^{-10}\\\\-0.085 & -9.554\\times10^{-08} & 0.301 & -0.002 & 1.847\\times10^{-08} & \\cdots & 2.048\\times10^{-08} & 2.181\\times10^{-08} & 2.198\\times10^{-08} & -2.874\\times10^{-08} & 2.137\\times10^{-11}\\\\-8.168\\times10^{-06} & 0.047 & -0.002 & 0.301 & 3.679\\times10^{-07} & \\cdots & 6.351\\times10^{-08} & 2.604\\times10^{-06} & 2.402\\times10^{-08} & -1.360\\times10^{-08} & 2.820\\times10^{-08}\\\\1.558 & 2.549\\times10^{-07} & 1.847\\times10^{-08} & 3.679\\times10^{-07} & 0.301 & \\cdots & -1.520\\times10^{-10} & -5.187\\times10^{-09} & -5.495\\times10^{-09} & 9.614\\times10^{-09} & -7.209\\times10^{-11}\\\\\\vdots & \\vdots & \\vdots & \\vdots & \\vdots & \\ddots & \\vdots & \\vdots & \\vdots & \\vdots & \\vdots\\\\-1.122\\times10^{-10} & 1.951\\times10^{-08} & 2.048\\times10^{-08} & 6.351\\times10^{-08} & -1.520\\times10^{-10} & \\cdots & 0.298 & 0.006 & -7.660\\times10^{-05} & -0.002 & -2.577\\\\1.605\\times10^{-10} & 8.473\\times10^{-09} & 2.181\\times10^{-08} & 2.604\\times10^{-06} & -5.187\\times10^{-09} & \\cdots & 0.006 & 0.302 & 0.083 & -0.277 & 0.021\\\\-9.217\\times10^{-11} & 1.147\\times10^{-08} & 2.198\\times10^{-08} & 2.402\\times10^{-08} & -5.495\\times10^{-09} & \\cdots & -7.660\\times10^{-05} & 0.083 & 0.302 & -0.006 & -0.461\\\\7.380\\times10^{-11} & -1.311\\times10^{-08} & -2.874\\times10^{-08} & -1.360\\times10^{-08} & 9.614\\times10^{-09} & \\cdots & -0.002 & -0.277 & -0.006 & 0.303 & -0.248\\\\-1.485\\times10^{-10} & 2.163\\times10^{-10} & 2.137\\times10^{-11} & 2.820\\times10^{-08} & -7.209\\times10^{-11} & \\cdots & -2.577 & 0.021 & -0.461 & -0.248 & 0.308\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[4, 4, 4], [4, 4, 4]], shape = (64, 64), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 3.00848255e-01 -3.94988892e-02 -8.51789422e-02 ... -9.21708710e-11\n",
+       "   7.38031846e-11 -1.48511179e-10]\n",
+       " [-3.94988892e-02  3.00848175e-01 -9.55399455e-08 ...  1.14676353e-08\n",
+       "  -1.31056971e-08  2.16270693e-10]\n",
+       " [-8.51789422e-02 -9.55399455e-08  3.00848062e-01 ...  2.19795959e-08\n",
+       "  -2.87402598e-08  2.13690326e-11]\n",
+       " ...\n",
+       " [-9.21708710e-11  1.14676353e-08  2.19795959e-08 ...  3.01845306e-01\n",
+       "  -6.18505106e-03 -4.60901874e-01]\n",
+       " [ 7.38031846e-11 -1.31056971e-08 -2.87402598e-08 ... -6.18505106e-03\n",
+       "   3.02528544e-01 -2.48191443e-01]\n",
+       " [-1.48511179e-10  2.16270693e-10  2.13690326e-11 ... -4.60901874e-01\n",
+       "  -2.48191443e-01  3.08183200e-01]]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_1_bare_eigenbasis = tmon1.n_operator(energy_esys=True)\n",
+    "hilbertspace.op_in_dressed_eigenbasis(op=(n_1_bare_eigenbasis, tmon1), op_in_bare_eigenbasis=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are thus two interfaces for this operator: the first is \n",
+    "\n",
+    "```hilbertspace.op_in_dressed_eigenbasis(op=op)```\n",
+    "\n",
+    "**Parameters**\n",
+    "\n",
+    "- *op* (callable): operator acting in Hilbert space of subsystem\n",
+    "\n",
+    "The second interface is\n",
+    "\n",
+    "```hilbertspace.op_in_dressed_eigenbasis(op=(op, subsys), op_in_bare_eigenbasis=False)```\n",
+    "\n",
+    "**Parameters**\n",
+    "\n",
+    "- *op* (ndarray, QuantumSys): pair of operator as ndarray as well as the subsystem to which the operator belongs\n",
+    "\n",
+    "- *op_in_bare_eigenbasis* (bool, optional): whether operator is given in the subsystem eigenbasis; otherwise, the internal QuantumSys basis is assumed\n",
+    "\n",
+    "**Return type**: Qobj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -844,7 +1025,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.7.7"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/source/guide/ipynb/hilbertspace.ipynb
+++ b/docs/source/guide/ipynb/hilbertspace.ipynb
@@ -1001,11 +1001,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The phases of the matrix elements of the operator in the dressed basis will depend on the phases of the dressed eigenvectors. To standardize those phases, `scqubits` also provides a helper function `hilbertspace.standardize_eigenvector_phases()` which standardizes the phases of the precalculated dressed eigenvectors. This function takes no arguments and returns nothing. It can be called before calling `op_in_dressed_eigenbasis`:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "hilbertspace.standardize_eigenvector_phases()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Docs and tutorial for new functions `op_in_dressed_eigenbasis` and `standardize_eigenvector_phases`. Also fixed some errors in the pre-existing docs due to `hilbertspace.lookup` being deprecated