### PR TITLE
pin sphinx<9 to keep pydata-sphinx-theme==0.9 working

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ pathos
 pygments>=2.4.1
 pydata-sphinx-theme==0.9
 scipy>=1.1.0
-sphinx>=4.5
+sphinx>=4.5,<9
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-design


### PR DESCRIPTION
Sphinx 9.0 changed Config.values entries from tuples to `_Opt` objects. The pinned pydata-sphinx-theme==0.9 (2022) still does `icon_default[1:]` on the stored value, raising

    TypeError: '_Opt' object is not subscriptable

from pydata_sphinx_theme.update_config on the env-updated event, which aborts the build with an ExtensionError. The RTD build against main hit this because requirements.txt only said `sphinx>=4.5`, so RTD pulled 9.0.4.

Pinning sphinx<9 keeps the themed build working without touching the theme pin. Once the theme is upgraded to a Sphinx-9-compatible release, both pins can be relaxed together.