### PR TITLE
bump scqubits pin from 4.3 to 4.3.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,4 +17,4 @@ sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-design
 sphinxcontrib-napoleon
-scqubits==4.3
+scqubits==4.3.1


### PR DESCRIPTION
scqubits 4.3.1 was released (May 2025) but docs/requirements.txt was never updated to match 

Bumping the pin resolves several RTD warnings whose root cause is the 4.3-vs-current module layout mismatch:

- autosummary: failed to import scqubits.ui.gui / gui_navbar / gui_setup (those submodules exist in 4.3.1 but not 4.3).
- AttributeError: module 'scqubits.ui.gui_custom_widgets' has no attribute 'ValidatedNumberField' / 'flex_column' (both are present in 4.3.1).
- Fallout from above: toctree contains reference to nonexisting document 'api-doc/_autosummary/scqubits.ui.gui.GUI'.

Does NOT resolve the "Unknown target name: lexical order" docstring errors or the Cos2PhiQubit line-block warning — those need upstream docstring fixes + a patch release.