### PR TITLE
docs: reflect scqubits 4.3.2 circuit-module refactor

### DIFF
--- a/docs/source/api-doc/circuit_classes.rst
+++ b/docs/source/api-doc/circuit_classes.rst
@@ -13,3 +13,4 @@ Circuit Classes
    _autosummary/scqubits.core.symbolic_circuit.SymbolicCircuit.rst
    _autosummary/scqubits.core.symbolic_circuit_graph.Node.rst
    _autosummary/scqubits.core.symbolic_circuit_graph.Branch.rst
+   _autosummary/scqubits.core.symbolic_circuit_graph.Coupler.rst

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,69 @@
 Change Log
 **********
 
+Version 4.3.2
++++++++++++++
+
+**ADDITIONS**
+
+    - Named constructors for `Circuit` from a YAML description:
+      `Circuit.from_yaml_file(path, ...)` (path on disk) and
+      `Circuit.from_yaml_string(yaml_text, ...)` (inline YAML). These
+      are the recommended replacements for the legacy
+      `Circuit(input_string=..., from_file=True/False)` form.
+    - New typed exception `ConfigureError` (subclass of `RuntimeError`)
+      raised by `Circuit.configure(...)` when reconfiguration fails.
+      The previous configuration is restored automatically and the
+      original cause is attached via `raise ... from exc`. The earlier
+      bare `except:` that silently swallowed errors during rollback is
+      gone.
+
+**DEPRECATIONS**
+
+    - The `from_file: bool` flag on `Circuit(input_string=..., from_file=...)`
+      now emits a `DeprecationWarning` whenever it is passed explicitly.
+      The legacy form continues to work but will be removed in a future
+      release; callers should migrate to `Circuit.from_yaml_file(...)`
+      or `Circuit.from_yaml_string(...)`.
+    - The `return_expr=True` flag on `sym_lagrangian`, `sym_hamiltonian`,
+      `sym_potential`, and `sym_interaction` is deprecated. Use the new
+      `*_expr` siblings (`sym_lagrangian_expr`, `sym_hamiltonian_expr`,
+      `sym_potential_expr`, `sym_interaction_expr`) which return the
+      symbolic expression directly. The flagged form continues to work
+      but emits a `DeprecationWarning`.
+
+**UNDER THE HOOD**
+
+    - Internal reorganization of the `Circuit` machinery.
+      Implementation modules previously at top-level
+      `scqubits.core.circuit_routines`, `scqubits.core.circuit_noise`,
+      `scqubits.core.circuit_plotting`, `scqubits.core.circuit_sym_methods`,
+      `scqubits.core.circuit_input`, and `scqubits.core.circuit_utils`
+      now live under the private subpackage
+      `scqubits.core.circuit_internals.*`. End-users are unaffected:
+      `circuit_input` and `circuit_utils` are kept as
+      re-export shims (the public free functions
+      `assemble_circuit`, `assemble_transformation_matrix`,
+      `sawtooth_operator`, `sawtooth_potential`, `truncation_template`,
+      `example_circuit`, the YAML parsing constants, etc., remain
+      importable from the same paths). The mixin-only shims
+      (`circuit_routines`, `circuit_noise`, `circuit_plotting`,
+      `circuit_sym_methods`) were removed; they only re-exported
+      classes (`CircuitRoutines`, `NoisyCircuit`, `CircuitPlot`,
+      `CircuitSymMethods`) that have no end-user use case.
+    - `CircuitRoutines` was split into four sibling mixins
+      (`SubsystemTreeMixin`, `HamiltonianAssemblyMixin`,
+      `LifecycleMixin`, plus the residual `CircuitRoutines`) covering
+      subsystem-tree construction, Hamiltonian assembly /
+      eigensystem computation, parameter sync / dispatch, and
+      Hilbert-space basics, respectively. Public `Circuit` /
+      `Subsystem` API and behaviour are unchanged.
+    - Numerical refactor regression test: a new characterization-test
+      suite (`scqubits/tests/test_circuit_characterization.py`) pins
+      `Circuit.hamiltonian()` and `Circuit.eigenvals(...)` against
+      committed `.npy` golden fixtures for four representative
+      circuits, plus five lifecycle-dispatch tests.
+
 Version 4.3.1
 +++++++++++++
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,6 +23,39 @@ Version 4.3.2
       original cause is attached via `raise ... from exc`. The earlier
       bare `except:` that silently swallowed errors during rollback is
       gone.
+    - `Circuit.operator(name, *, energy_esys=False)` -- typed
+      dispatcher that resolves to the dynamic per-variable operator
+      methods (`n1_operator`, `θ1_operator`, `cosθ1_operator`, etc.)
+      bound during `_configure`. The dynamic methods themselves are
+      bound via `types.MethodType` and are therefore invisible to
+      `mypy` / IDE autocomplete / `sphinx-autodoc`; the new accessor
+      restores static-tooling visibility. The dynamic methods stay
+      for back-compat.
+    - `NoisyCircuit.channels()` -- explicit registry of installed
+      noise-channel methods, returned as a `dict[str, Callable]`
+      mapping each generated method name (e.g. `t1_capacitive`,
+      `t1_inductive3`, `tphi_1_over_f_flux1`) to its bound callable.
+      `Circuit.supported_noise_channels()` now reads from this
+      registry instead of walking `self.__dict__` and substring
+      matching on names.
+
+**FIXES**
+
+    - `Circuit(symbolic_hamiltonian=...).configure(transformation_matrix=...)`
+      now raises `ValueError`. Previously the keyword argument was
+      silently dropped on this construction path (the
+      `_configure_sym_hamiltonian` branch did not consume
+      `transformation_matrix`, but the validation in
+      `Circuit.configure` omitted the keyword from the rejected list
+      even though the existing error message already named it as
+      forbidden). The other three keywords already rejected on this
+      path -- `closure_branches`, `use_dynamic_flux_grouping`,
+      `generate_noise_methods` -- are unchanged.
+    - `_evaluate_matrix_sawtooth_terms` now uses the per-term
+      coefficient when assembling a multi-term sawtooth potential.
+      Previously every term picked up the first coefficient of the
+      outer expression, so circuits with multiple `JJs` branches at
+      different `EJ` values produced an incorrect matrix.
 
 **DEPRECATIONS**
 
@@ -67,8 +100,63 @@ Version 4.3.2
     - Numerical refactor regression test: a new characterization-test
       suite (`scqubits/tests/test_circuit_characterization.py`) pins
       `Circuit.hamiltonian()` and `Circuit.eigenvals(...)` against
-      committed `.npy` golden fixtures for four representative
-      circuits, plus five lifecycle-dispatch tests.
+      committed `.npy` golden fixtures.  Originally four
+      representative circuits; expanded to seven with `ungrounded`
+      (sigma-mode coverage), `ml_coupled` (mutual inductance), and
+      `jj2` (higher-order Josephson junction) fixtures.  Each
+      fixture now also writes a JSON sidecar carrying the first six
+      eigenvalues + gaps and the Hamiltonian's shape, trace, and
+      Frobenius norm, so reviewers of numerical-change PRs can see
+      what actually moved instead of reading a binary diff.
+    - The `CircuitRoutines` mixin chain was further consolidated.
+      A single `CircuitProtocol` (in
+      `scqubits/core/circuit_internals/_protocols.py`) now declares
+      the cross-mixin attribute and method surface that the five
+      sibling mixins (`LifecycleMixin`, `SubsystemTreeMixin`,
+      `HamiltonianAssemblyMixin`, `CircuitSymMethods`, `CircuitPlot`)
+      previously each redeclared inside their own
+      `if TYPE_CHECKING:` blocks. At runtime `CircuitProtocol` is an
+      empty class (its body is gated under `TYPE_CHECKING`); the
+      addition to the MRO is a no-op.
+    - Josephson cosine/sine matrix evaluation pipeline lifted from
+      `HamiltonianAssemblyMixin` into a sibling module
+      `scqubits/core/circuit_internals/junction_assembly.py`.
+      `HamiltonianAssemblyMixin` keeps two thin wrapper methods
+      (`_evaluate_matrix_cosine_terms`,
+      `_evaluate_matrix_sawtooth_terms`) so the existing call surface
+      is preserved.
+    - The 18-attribute "what flows from the symbolic to the
+      numerical layer" contract is now pinned by a class-level
+      constant `SymbolicCircuit._STAGE2_ATTRIBUTES`. Adding a new
+      attribute that should propagate from `SymbolicCircuit` to
+      `Circuit` requires updating only that tuple; a parametrized
+      regression test (`TestRecomputationContract`) flags any name
+      that fails to reach a freshly-constructed `Circuit`.
+    - `Circuit._clear_unnecessary_attribs` is now driven by an
+      explicit registry (`self._dynamic_var_attribs`) populated by
+      `_install_var_properties`, replacing the prior string-substring
+      matching on attribute names. Adding a new per-variable property
+      kind no longer requires updating two unrelated places.
+    - The vestigial `Node.marker` field and its dead-code writer
+      `_mark_nodes_by_subgraph` have been removed; `_independent_modes`
+      uses pure return values.
+    - New developer's manual at the repository root
+      (`CIRCUIT_DEVELOPER_MANUAL.md`, ~1500 lines) covers the
+      circuit module's internal structure, mixin composition, graph
+      algorithms, hierarchical-diagonalization flow, parameter
+      lifecycle and central dispatch, noise model, plotting,
+      symbolic methods, public API surface, performance hot paths,
+      extension recipes, and a "where to look for what" lookup
+      table. Audited by an independent reviewer.
+    - New project-level docstring linter
+      (`tools/docstring_lint.py`) and accompanying GitHub Actions
+      workflow (`.github/workflows/docstring-lint.yml`) check
+      docstring rules (placeholder phrases, types duplicated into
+      Parameters / Returns sections that the signature already
+      declares, refactor-history phrasing, empty numpydoc section
+      headers). The CI workflow runs in `--compare-to origin/main`
+      mode, so only docstring issues newly introduced by a PR can
+      fail the build.
 
 Version 4.3.1
 +++++++++++++

--- a/docs/source/guide/circuit/ipynb/custom_circuit_bases.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_bases.ipynb
@@ -37,7 +37,7 @@
     "- [C, 2,4, 0.02]\n",
     "\"\"\"\n",
     "\n",
-    "zero_pi = scq.Circuit(zp_yaml, from_file=False)"
+    "zero_pi = scq.Circuit.from_yaml_string(zp_yaml)"
    ]
   },
   {
@@ -59,7 +59,7 @@
     "\n",
     "For instance, the following would switch the treatment of the extended degrees of freedom to using harmonic-oscillator basis:\n",
     "\n",
-    "`zero_pi = scq.Circuit(zp_yaml, from_file=False, ext_basis=\"harmonic\")`"
+    "`zero_pi = scq.Circuit.from_yaml_string(zp_yaml, ext_basis=\"harmonic\")`"
    ]
   },
   {
@@ -286,7 +286,7 @@
     "- [C, 3, 4, 0.5]\n",
     "- [L, 4, 0, 8]\n",
     "\"\"\"\n",
-    "circ = scq.Circuit(full_yaml, from_file=False, ext_basis=\"discretized\")"
+    "circ = scq.Circuit.from_yaml_string(full_yaml, ext_basis=\"discretized\")"
    ]
   },
   {
@@ -373,7 +373,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circ = scq.Circuit(full_yaml, from_file=False, ext_basis=\"discretized\")\n",
+    "circ = scq.Circuit.from_yaml_string(full_yaml, ext_basis=\"discretized\")\n",
     "trans_mat = np.array([[1, 0, 0, 0], \n",
     "                      [0, 1, 0, 0], \n",
     "                      [0, 0, 1, 0],\n",

--- a/docs/source/guide/circuit/ipynb/custom_circuit_coherence_estimates.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_coherence_estimates.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circ = scq.Circuit(snail_yaml, from_file=False, use_dynamic_flux_grouping=True, generate_noise_methods=True)"
+    "circ = scq.Circuit.from_yaml_string(snail_yaml, use_dynamic_flux_grouping=True, generate_noise_methods=True)"
    ]
   },
   {

--- a/docs/source/guide/circuit/ipynb/custom_circuit_define.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_define.ipynb
@@ -101,7 +101,7 @@
     "- `scq.Circuit.from_yaml_file(path, ...)` for a YAML file on disk.\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
-    "<b>Deprecated form.</b> The earlier <code>Circuit(input_string=..., from_file=True/False)</code> constructor still works, but passing <code>from_file</code> explicitly now emits a <code>DeprecationWarning</code>. New code should use the named constructors above.\n",
+    "**Deprecated form.** The earlier `Circuit(input_string=..., from_file=True/False)` constructor still works, but passing `from_file` explicitly now emits a `DeprecationWarning`. New code should use the named constructors above.\n",
     "</div>"
    ]
   },

--- a/docs/source/guide/circuit/ipynb/custom_circuit_define.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_define.ipynb
@@ -95,7 +95,14 @@
     }
    },
    "source": [
-    "Alternatively, circuit specifications can be stored and loaded as `yaml` files (same syntax as above), which can be directly provided to the `Circuit` class."
+    "Once a YAML description has been prepared (either inline as a string, or saved as a `.yaml` file), a `Circuit` object can be constructed via the named constructors:\n",
+    "\n",
+    "- `scq.Circuit.from_yaml_string(yaml_text, ...)` for an inline string;\n",
+    "- `scq.Circuit.from_yaml_file(path, ...)` for a YAML file on disk.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "<b>Deprecated form.</b> The earlier <code>Circuit(input_string=..., from_file=True/False)</code> constructor still works, but passing <code>from_file</code> explicitly now emits a <code>DeprecationWarning</code>. New code should use the named constructors above.\n",
+    "</div>"
    ]
   },
   {

--- a/docs/source/guide/circuit/ipynb/custom_circuit_define_more.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_define_more.ipynb
@@ -141,7 +141,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "zero_pi = scq.Circuit(zp_yaml, from_file=False)"
+    "zero_pi = scq.Circuit.from_yaml_string(zp_yaml)"
    ]
   },
   {

--- a/docs/source/guide/circuit/ipynb/custom_circuit_extra.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_extra.ipynb
@@ -127,7 +127,7 @@
     }
    ],
    "source": [
-    "zero_pi = scq.Circuit(zp_yaml, from_file=False, use_dynamic_flux_grouping=True)\n",
+    "zero_pi = scq.Circuit.from_yaml_string(zp_yaml, use_dynamic_flux_grouping=True)\n",
     "zero_pi.sym_external_fluxes()"
    ]
   },
@@ -163,7 +163,7 @@
    },
    "outputs": [],
    "source": [
-    "zero_pi = scq.Circuit(zp_yaml, from_file=False, ext_basis=\"harmonic\")"
+    "zero_pi = scq.Circuit.from_yaml_string(zp_yaml, ext_basis=\"harmonic\")"
    ]
   },
   {
@@ -344,7 +344,7 @@
     }
    ],
    "source": [
-    "circ = scq.Circuit(circ_input, from_file=False)\n",
+    "circ = scq.Circuit.from_yaml_string(circ_input)\n",
     "circ"
    ]
   },

--- a/docs/source/guide/circuit/ipynb/custom_circuit_hamiltonian.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_hamiltonian.ipynb
@@ -37,7 +37,7 @@
     "- [C, 2,4, 0.02]\n",
     "\"\"\"\n",
     "\n",
-    "zero_pi = scq.Circuit(zp_yaml, from_file=False)"
+    "zero_pi = scq.Circuit.from_yaml_string(zp_yaml)"
    ]
   },
   {

--- a/docs/source/guide/circuit/ipynb/custom_circuit_lagrangian.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_lagrangian.ipynb
@@ -40,7 +40,7 @@
     "- [C, 2,4, 0.02]\n",
     "\"\"\"\n",
     "\n",
-    "zero_pi = scq.Circuit(zp_yaml, from_file=False)"
+    "zero_pi = scq.Circuit.from_yaml_string(zp_yaml)"
    ]
   },
   {

--- a/docs/source/guide/circuit/ipynb/custom_circuit_parametric_driving.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_parametric_driving.ipynb
@@ -112,7 +112,7 @@
     "- [L, 1, 2, 1.3]\n",
     "- [C, 1, 2, 2]\n",
     "\"\"\"\n",
-    "circ = scq.Circuit(inp_yaml, from_file=False, use_dynamic_flux_grouping=True, ext_basis=\"discretized\")\n",
+    "circ = scq.Circuit.from_yaml_string(inp_yaml, use_dynamic_flux_grouping=True, ext_basis=\"discretized\")\n",
     "circ.cutoff_ext_1 = 100\n",
     "circ.Φ1 = 0.5\n",
     "\n",

--- a/docs/source/guide/circuit/ipynb/custom_circuit_visualization.ipynb
+++ b/docs/source/guide/circuit/ipynb/custom_circuit_visualization.ipynb
@@ -22,7 +22,7 @@
     "- [\"C\", 2,4, 0.02]\n",
     "\"\"\"\n",
     "\n",
-    "zero_pi = scq.Circuit(zp_yaml, from_file=False)\n",
+    "zero_pi = scq.Circuit.from_yaml_string(zp_yaml)\n",
     "system_hierarchy = [[1,3], [2]]\n",
     "\n",
     "zero_pi.cutoff_n_1 = 15\n",


### PR DESCRIPTION
Documents the circuit-module refactor landing in scqubits 4.3.2 (scqubits PRs #289 / #290 / #291), now on scqubits `main`.

## Changelog

New "Version 4.3.2" entry covering:

- **Additions** — `Circuit.from_yaml_file` / `Circuit.from_yaml_string` named constructors; `Circuit.operator(name, *, energy_esys=False)` typed dispatcher for the dynamic per-variable operator methods; `NoisyCircuit.channels()` registry-based noise-channel introspection; `ConfigureError` exception type.
- **Deprecations** — the `from_file: bool` flag on `Circuit(...)`; the `return_expr=True` flag on the `sym_*` accessors. No public API was renamed or removed.
- **Fixes** — `Circuit(symbolic_hamiltonian=...).configure(transformation_matrix=...)` now raises `ValueError` instead of silently dropping the kwarg; sawtooth term evaluation honors per-term coefficients for multi-`JJs` circuits.
- **Under the hood** — `circuit_internals` subpackage; `CircuitRoutines` split into four sibling mixins; `CircuitProtocol` consolidates cross-mixin `TYPE_CHECKING` declarations; JJ matrix-evaluation pipeline lifted to `circuit_internals/junction_assembly.py`; recomputation contract pinned by `SymbolicCircuit._STAGE2_ATTRIBUTES`; characterization fixtures expanded 4 -> 7.

## Notebook migrations

Across the circuit-tutorial notebooks in `guide/circuit/ipynb/`, the deprecated `scq.Circuit(yaml, from_file=False/True)` pattern is replaced with `Circuit.from_yaml_string(yaml)` / `Circuit.from_yaml_file(...)`. `custom_circuit_define.ipynb` gains a markdown note introducing the named constructors as the recommended construction path and flagging the legacy form as deprecated.

Code-cell behavior is unchanged — the migration just removes a `DeprecationWarning` that would otherwise surface in re-executed notebooks. All notebooks pass `nbformat.validate`; outputs and execution counts are preserved.

## Other

- `custom_circuit_define.ipynb`: the "Deprecated form." callout used a `<b>` tag inside an `alert` div that the notebook renderer strips; switched to Markdown bold so it renders in both nbsphinx and Jupyter. Inline `<code>` tags converted to backtick-fenced inline code for the same reason.
- `circuit_classes.rst`: added the missing `Coupler` toctree entry (its autosummary stub was already being generated; only the toctree entry was absent).

## Notes

- `docs/requirements.txt` still pins `scqubits==4.3.1`; this PR documents 4.3.2 behavior ahead of that release, consistent with `main` tracking scqubits `main`. The notebooks carry cached outputs, so RTD does not re-execute them against the older pin.
- Stale `api-doc/_autosummary/` stubs for the removed shim modules (`circuit_routines`, `circuit_noise`, `circuit_plotting`, `circuit_sym_methods`) need no deletion — that tree is gitignored and regenerated per build.

## Test plan

- [ ] RTD build succeeds.
- [ ] Circuit guide notebooks render; no `from_file` deprecation text visible.