### PR TITLE
docs(explorer): drop "explorer =" so the widget auto-displays again

### DIFF
--- a/docs/source/guide/explorer/ipynb/explorer.ipynb
+++ b/docs/source/guide/explorer/ipynb/explorer.ipynb
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-02-13T22:51:30.660521Z",
@@ -226,25 +226,8 @@
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6025cf0d0eef448f84e83cd9ce7a4ffc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Container(children=[Sheet(children=[Card(children=[Img(layout=None, src='data:image/png;base64,iVBORw0KGgoAAAA…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "explorer = scq.Explorer(sweep)"
-   ]
+   "outputs": [],
+   "source": "scq.Explorer(sweep)"
   },
   {
    "cell_type": "markdown",
@@ -462,9 +445,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "explorer = scq.Explorer(sweep=sweep)"
-   ]
+   "source": "scq.Explorer(sweep=sweep)"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Companion to scqubits PR #292 (`refactor(explorer): per-PlotType PanelBuilder registry + typed UI state`).

That refactor moves the `Explorer` auto-display out of `Explorer.__init__` and into an `_ipython_display_` method. This is the Pythonic behavior — construction no longer has a `display()` side effect — but it has one user-visible consequence: a bare `scq.Explorer(sweep)` cell still renders, while an **assignment** `explorer = scq.Explorer(sweep)` does not, because Jupyter only invokes `_ipython_display_` on the value of a cell's final expression, and an assignment statement has no value.

Both Explorer instantiations in the Explorer guide notebook used the assignment form and never referenced the `explorer` name again, so the cleanest fix is to drop the assignment and let the bare expression auto-display:

- `explorer = scq.Explorer(sweep)` -> `scq.Explorer(sweep)`
- `explorer = scq.Explorer(sweep=sweep)` -> `scq.Explorer(sweep=sweep)`

## Notes

- Notebook validates against nbformat v4.
- Should merge together with (or just after) scqubits PR #292 — on its own against the current released scqubits it is harmless (a bare expression auto-displays under both the old and new behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)