### PR TITLE
chore: update GitHub username jkochNU -> kochjens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 scqubits: superconducting qubits in Python
 ===========================================
 
-[J. Koch](https://github.com/jkochNU), [P. Groszkowski](https://github.com/petergthatsme)
+[J. Koch](https://github.com/kochjens), [P. Groszkowski](https://github.com/petergthatsme)
 
 
 **This repository contains the source files for the documentation of the scqubits library, generated via Sphinx and available on ReadTheDocs.**


### PR DESCRIPTION
Refresh the stale maintainer link in the README to the renamed GitHub account. No build/content changes otherwise.

**Test plan**
- [x] `git grep jkochNU` clean in tracked source (the `docs/build` hits are generated/gitignored)
- [ ] RTD build green