### PR TITLE
docs(convergence): define U_N in the cluster-safe-matching section [#306]

### DIFF
--- a/docs/source/guide/convergence/guide-convergence.rst
+++ b/docs/source/guide/convergence/guide-convergence.rst
@@ -371,15 +371,27 @@ Cluster-safe matching
 Near degeneracies, matching levels by index is unreliable. Consecutive levels
 whose internal gaps are small compared with the neighboring external gaps are
 grouped into a *cluster*, compared as a sorted set, and assigned a common
-error estimate plus a ``cluster_index_ambiguity`` warning. The subspace
-diagnostic for a cluster spanned by :math:`U_{N_0}`, :math:`U_{N_1}` is the sine
-of the largest principal angle,
+error estimate plus a ``cluster_index_ambiguity`` warning.
+
+Here :math:`U_{N_0}` and :math:`U_{N_1}` are the **eigenvector blocks** spanning
+that cluster at two cutoffs :math:`N_0` and :math:`N_1` -- the relevant columns
+of the diagonalizing unitary (orthonormal, embedded in a common basis). Inside a
+(near-)degenerate block the individual eigenvectors are not physically
+well-defined -- they can rotate arbitrarily among themselves between cutoffs --
+so the diagnostic compares the *spans* of the blocks rather than vector-by-vector
+overlaps. The subspace diagnostic is the sine of the largest principal angle
+between those two spans,
 
 .. math::
 
    \sin\Theta = \bigl\| (I - U_{N_0} U_{N_0}^\dagger)\, U_{N_1} \bigr\|_2,
 
-which is robust to eigenvector rotations within the block.
+which is :math:`0` when the cluster's eigenspace is unchanged under refinement
+and :math:`1` when it has rotated to a fully orthogonal direction. It is the
+cluster-level analogue of one minus a wavefunction overlap, robust to eigenvector
+rotations within the block. Being built from eigenvectors alone, it is
+dimensionless and independent of the active energy unit
+(:func:`~scqubits.set_units`); it is *not* one of the GHz-valued error estimates.
 
 .. _guide_convergence_monotonicity:
 


### PR DESCRIPTION
Addresses point #3 of scqubits issue [#306](https://github.com/scqubits/scqubits/issues/306) (raised by @Harrinive): *"I am not sure how those `U_N` are defined."* The screenshot in that issue is this **Cluster-safe matching** section of the convergence guide, which used :math:`U_{N_0}, U_{N_1}` without defining them.

This adds the definition:

- :math:`U_{N_0}, U_{N_1}` are the **eigenvector blocks** spanning the cluster at two cutoffs (the relevant columns of the diagonalizing unitary, orthonormal in a common basis).
- Explains *why* spans (not individual eigenvectors) are compared: degenerate eigenvectors rotate arbitrarily between cutoffs.
- States the :math:`\sin\Theta` 0..1 meaning (0 = eigenspace unchanged under refinement; 1 = rotated to an orthogonal direction).
- Notes it is **dimensionless and independent of `set_units`** — i.e. *not* one of the GHz-valued error estimates (those are addressed separately by scqubits PR #316).

Docs only. RST parses cleanly; `:func:` ref style matches the rest of the guide.

> Companion: scqubits PR #317 adds the same definition to the `subspace_angle` code docstring (for API/autodoc readers); this PR fixes the narrative guide page that the issue screenshot came from.