### PR TITLE
documentation for cuQuantum integration

### DIFF
--- a/docs/source/guide/hilbertspace/ipynb/cuquantum.ipynb
+++ b/docs/source/guide/hilbertspace/ipynb/cuquantum.ipynb
@@ -17,12 +17,28 @@
     "\n",
     "Using these features requires an NVIDIA GPU with a compatible CUDA driver and a working installation of [qutip-cuquantum](https://github.com/qutip/qutip-cuquantum#installation). qutip-cuquantum relies on NVIDIA cuQuantum Python (including cuDensityMat) and CuPy at runtime; these optional packages are not installed with scqubits. Follow the qutip-cuquantum installation instructions for the CUDA version available on your system.\n",
     "\n",
+    "```{=rst}\n",
+    ".. warning::\n",
+    "\n",
+    "   Run all scqubits code outside ``CuQuantumBackend``. scqubits already manages\n",
+    "   the shared workstream internally for its cuQuantum operations. Activating\n",
+    "   the backend changes QuTiP defaults that scqubits does not support. Use the\n",
+    "   backend only around qutip-cuquantum operations; scqubits calls may be made\n",
+    "   before entering or after exiting the backend context.\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We can verify the installation and confirm that a CUDA-capable GPU is available as follows:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -74,14 +90,14 @@
     "\n",
     "### Eigensystems\n",
     "\n",
-    "scqubits supports sparse diagonalization through cuDensityMat's Krylov eigensolver, which computes a subset of the spectrum. Set `esys_method` to `\"esys_cuquantum\"` to calculate a requested number of low-energy eigenpairs.\n",
+    "scqubits supports sparse diagonalization of composite `HilbertSpace` systems through cuDensityMat's Krylov eigensolver, which computes a subset of the spectrum. The cuQuantum eigensolver is not supported for individual scqubits subsystems such as qubits. Set `esys_method` to `\"esys_cuquantum\"` to calculate a requested number of low-energy eigenpairs.\n",
     "\n",
     "```python\n",
     "hilbert_space.esys_method = \"esys_cuquantum\"\n",
     "evals, evecs = hilbert_space.eigensys(evals_count=5)\n",
     "```\n",
     "\n",
-    "When only eigenvalues are needed, use `evals_method=\"evals_cuquantum\"` with `HilbertSpace.eigenvals`.\n",
+    "When only eigenvalues are needed, use `evals_method=\"evals_cuquantum\"` with `HilbertSpace.eigenvals`. See [Eigensolver settings and limitations](#Eigensolver-settings-and-limitations) for the Krylov parameters and restrictions on the number of requested eigenpairs.\n",
     "\n",
     "### Workstream management\n",
     "\n",
@@ -154,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -181,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -190,7 +206,7 @@
        "qutip_cuquantum.operator.CuOperator"
       ]
      },
-     "execution_count": 4,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -226,7 +242,7 @@
        "        4.62471681,  5.03748573,  5.16673276,  6.43217623,  7.65245281])"
       ]
      },
-     "execution_count": 5,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -259,7 +275,7 @@
        "np.float64(5.50135526151138)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -288,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,12 +378,44 @@
     "print(f\"Maximum resonator occupation: {occupation.max():.9g}\")\n",
     "print(f\"Final resonator occupation: {occupation[-1]:.9g}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Eigensolver settings and limitations\n",
+    "\n",
+    "### Krylov settings\n",
+    "\n",
+    "The cuQuantum eigensolver reads the following attributes from `scq.settings` on each call. The settings apply to both `evals_cuquantum` and `esys_cuquantum`.\n",
+    "\n",
+    "| Setting | scqubits default | Meaning |\n",
+    "| --- | --- | --- |\n",
+    "| `CUQUANTUM_MIN_KRYLOV_BLOCK_SIZE` ($b$) | `1` | Minimum number of vectors in a Krylov block. |\n",
+    "| `CUQUANTUM_MAX_BUFFER_RATIO` ($r$) | `5` | Maximum ratio of Krylov subspace blocks to requested eigenpairs. |\n",
+    "| `CUQUANTUM_MAX_RESTARTS` | `20` | Maximum number of restart cycles. |\n",
+    "\n",
+    "Larger blocks and subspaces may improve convergence at the cost of additional memory and computation. Increasing the restart limit allows more iterations. The buffer ratio must be greater than one. See NVIDIA's [OperatorSpectrumConfig documentation](https://docs.nvidia.com/cuda/cuquantum/latest/python/generated/cuquantum.densitymat.OperatorSpectrumConfig.html) for details.\n",
+    "\n",
+    "Set these attributes before calling `eigensys`, `eigenvals`, or `generate_lookup`.\n",
+    "\n",
+    "### Partial spectra and lookup generation\n",
+    "\n",
+    "The Krylov solver is intended for a subset of low-energy eigenpairs. For a composite Hilbert space of dimension $D$, the maximum number of eigenpairs a user can request is\n",
+    "\n",
+    "\\begin{equation}\n",
+    "k_\\mathrm{max} = \\left\\lfloor \\frac{D-b}{2br} \\right\\rfloor,\n",
+    "\\end{equation}\n",
+    "\n",
+    "Increasing the minimum Krylov block size ($b$) or maximum buffer ratio ($r$) can lower this limit. Set `evals_count` to no more than $k_\\mathrm{max}$ when calling `eigenvals` or `eigensys`.\n",
+    "\n",
+    "For `generate_lookup`, use `ordering=\"BE\"` and explicitly set `BEs_count` to the number of eigenpairs to calculate, also no greater than $k_\\mathrm{max}$. Call `generate_lookup` outside `CuQuantumBackend`, as shown in the workflow above.\n",
+    "\n",
+    "The `\"DE\"` and `\"LX\"` lookup orderings require a full eigensystem and are not supported with `esys_cuquantum`. Omitting `BEs_count` also requests a full eigensystem. If a full spectrum or either of these orderings is needed, select an alternative method described in [User-defined Diagonalization](../../settings/ipynb/custom_diagonalization.ipynb)."
+   ]
   }
  ],
  "metadata": {
-  "nbsphinx": {
-   "execute": "never"
-  },
   "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -385,6 +433,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.8"
+  },
+  "nbsphinx": {
+   "execute": "never"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/source/guide/hilbertspace/ipynb/cuquantum.ipynb
+++ b/docs/source/guide/hilbertspace/ipynb/cuquantum.ipynb
@@ -1,0 +1,434 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GPU acceleration with NVIDIA cuQuantum\n",
+    "\n",
+    "scqubits provides optional support for NVIDIA cuQuantum to accelerate selected calculations for composite quantum systems on NVIDIA GPUs. Building on the [HilbertSpace](./hilbertspace.ipynb) workflow, this guide shows how to construct cuQuantum-backed operators and calculate low-energy eigenpairs. It also shows how scqubits-generated models can be used with qutip-cuquantum for GPU-accelerated dynamics."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preliminaries and dependencies\n",
+    "\n",
+    "Using these features requires an NVIDIA GPU with a compatible CUDA driver and a working installation of [qutip-cuquantum](https://github.com/qutip/qutip-cuquantum#installation). qutip-cuquantum relies on NVIDIA cuQuantum Python (including cuDensityMat) and CuPy at runtime; these optional packages are not installed with scqubits. Follow the qutip-cuquantum installation instructions for the CUDA version available on your system.\n",
+    "\n",
+    "We can verify the installation and confirm that a CUDA-capable GPU is available as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CUDA device 0: NVIDIA GeForce RTX 5090\n"
+     ]
+    }
+   ],
+   "source": [
+    "import cupy\n",
+    "import cuquantum\n",
+    "import qutip_cuquantum as qcu\n",
+    "\n",
+    "device_id = cupy.cuda.Device().id\n",
+    "device_name = cupy.cuda.runtime.getDeviceProperties(device_id)[\"name\"].decode()\n",
+    "print(f\"CUDA device {device_id}: {device_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## cuQuantum features in scqubits\n",
+    "\n",
+    "scqubits provides cuQuantum support for constructing composite operators and calculating partial eigensystems. These features are enabled explicitly and do not change the default CPU behavior.\n",
+    "\n",
+    "### Composite Hamiltonians\n",
+    "\n",
+    "`HilbertSpace.hamiltonian` can construct a composite Hamiltonian in the qutip-cuquantum representation used by cuDensityMat. The result remains a QuTiP `Qobj`, with its data represented by a `CuOperator`.\n",
+    "\n",
+    "```python\n",
+    "hamiltonian = hilbert_space.hamiltonian(use_cuquantum=True)\n",
+    "```\n",
+    "\n",
+    "### Identity-wrapped operators\n",
+    "\n",
+    "`identity_wrap` expresses an operator acting on a subsystem in the bare product basis of the composite Hilbert space. Setting `use_cuquantum=True` constructs the resulting composite operator in the same qutip-cuquantum representation.\n",
+    "\n",
+    "```python\n",
+    "wrapped_operator = scq.identity_wrap(\n",
+    "    subsystem_operator,\n",
+    "    subsystem,\n",
+    "    hilbert_space.subsystem_list,\n",
+    "    use_cuquantum=True,\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "### Eigensystems\n",
+    "\n",
+    "scqubits supports sparse diagonalization through cuDensityMat's Krylov eigensolver, which computes a subset of the spectrum. Set `esys_method` to `\"esys_cuquantum\"` to calculate a requested number of low-energy eigenpairs.\n",
+    "\n",
+    "```python\n",
+    "hilbert_space.esys_method = \"esys_cuquantum\"\n",
+    "evals, evecs = hilbert_space.eigensys(evals_count=5)\n",
+    "```\n",
+    "\n",
+    "When only eigenvalues are needed, use `evals_method=\"evals_cuquantum\"` with `HilbertSpace.eigenvals`.\n",
+    "\n",
+    "### Workstream management\n",
+    "\n",
+    "cuDensityMat objects must use the same `WorkStream` to interact with one another. scqubits therefore uses a single workstream for its cuQuantum operations. `get_cuquantum_workstream` creates the default workstream on first use and returns the same instance on subsequent calls. To create compatible objects outside scqubits, retrieve and reuse this workstream:\n",
+    "\n",
+    "```python\n",
+    "workstream = scq.get_cuquantum_workstream()\n",
+    "```\n",
+    "\n",
+    "If objects created outside scqubits already use a workstream, register that same instance with scqubits before using its cuQuantum features:\n",
+    "\n",
+    "```python\n",
+    "scq.set_cuquantum_workstream(custom_workstream)\n",
+    "```\n",
+    "\n",
+    "Registration must occur before the first call to `get_cuquantum_workstream` or any scqubits cuQuantum operation. Once initialized, the workstream cannot be replaced during the same Python process."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `HilbertSpace` workflow with cuQuantum\n",
+    "\n",
+    "The usual scqubits workflow for defining a composite system is unchanged when using cuQuantum. As an example, consider a fluxonium charge coupled to a harmonic resonator,\n",
+    "\n",
+    "\\begin{equation}\n",
+    "H = H_\\mathrm{f} + H_\\mathrm{r} + g n_\\mathrm{f} n_\\mathrm{r}.\n",
+    "\\end{equation}\n",
+    "\n",
+    "We first create the subsystems and add the interaction to a `HilbertSpace`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fluxonium = scq.Fluxonium(\n",
+    "    EJ=3.395,\n",
+    "    EC=1.0,\n",
+    "    EL=0.132,\n",
+    "    flux=0.5,\n",
+    "    cutoff=110,\n",
+    "    truncated_dim=20,\n",
+    ")\n",
+    "resonator = scq.Oscillator(\n",
+    "    E_osc=5.5,\n",
+    "    l_osc=1.0,\n",
+    "    truncated_dim=50,\n",
+    ")\n",
+    "\n",
+    "hilbert_space = scq.HilbertSpace([fluxonium, resonator])\n",
+    "hilbert_space.add_interaction(\n",
+    "    g_strength=0.1,\n",
+    "    op1=fluxonium.n_operator,\n",
+    "    op2=resonator.n_operator,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Hamiltonian and composite operators\n",
+    "\n",
+    "Passing `use_cuquantum=True` constructs the Hamiltonian with the qutip-cuquantum data layer, using scqubits' shared workstream. If no workstream has been registered, a default workstream is created automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'qutip.core.qobj.Qobj'>\n",
+      "<class 'qutip_cuquantum.operator.CuOperator'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "hamiltonian = hilbert_space.hamiltonian(use_cuquantum=True)\n",
+    "print(type(hamiltonian))\n",
+    "print(type(hamiltonian.data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use `identity_wrap` to express the resonator charge operator in the composite Hilbert space for the drive used below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "qutip_cuquantum.operator.CuOperator"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resonator_charge = scq.identity_wrap(\n",
+    "    resonator.n_operator(),\n",
+    "    resonator,\n",
+    "    hilbert_space.subsystem_list,\n",
+    "    use_cuquantum=True,\n",
+    ")\n",
+    "type(resonator_charge.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Low-energy eigensystem\n",
+    "\n",
+    "We use `generate_lookup` to calculate ten low-energy eigenpairs and assign bare-state labels using bare-energy ordering. With `esys_method=\"esys_cuquantum\"`, it internally calls `eigensys` using the cuQuantum eigensolver."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-0.46386953, -0.33372671,  3.17180909,  4.09615664,  4.47101911,\n",
+       "        4.62471681,  5.03748573,  5.16673276,  6.43217623,  7.65245281])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hilbert_space.esys_method = \"esys_cuquantum\"\n",
+    "hilbert_space.generate_lookup(ordering=\"BE\", BEs_count=10)\n",
+    "evals = hilbert_space[\"evals\"][0]\n",
+    "evecs = hilbert_space[\"evecs\"][0]\n",
+    "evals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Resonator charge-drive dynamics\n",
+    "\n",
+    "The cuQuantum-backed Hamiltonian and operators can be passed to qutip-cuquantum for time evolution. We drive the resonator at the dressed $|0,0\\rangle \\rightarrow |0,1\\rangle$ transition, starting from the dressed ground state. We use the eigenpairs calculated above to set the drive frequency and initial state:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.float64(5.50135526151138)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drive_frequency = hilbert_space.energy_by_bare_index(\n",
+    "    (0, 1), subtract_ground=True\n",
+    ")\n",
+    "ground_index = hilbert_space.dressed_index((0, 0))\n",
+    "initial_state = evecs[ground_index]\n",
+    "drive_frequency"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The driven Hamiltonian is\n",
+    "\n",
+    "\\begin{equation}\n",
+    "H(t) = H + A \\cos(2\\pi f_\\mathrm{d} t)n_\\mathrm{r},\n",
+    "\\end{equation}\n",
+    "\n",
+    "We use a drive amplitude of $A=0.005$ GHz and evolve the closed system for 50 ns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "drive_amplitude = 0.005\n",
+    "times = np.linspace(0.0, 50.0, 201)\n",
+    "\n",
+    "def drive(t, amplitude, frequency):\n",
+    "    return amplitude * np.cos(2 * np.pi * frequency * t)\n",
+    "\n",
+    "driven_hamiltonian = qt.QobjEvo(\n",
+    "    [\n",
+    "        2 * np.pi * hamiltonian,\n",
+    "        [2 * np.pi * resonator_charge, drive],\n",
+    "    ],\n",
+    "    args={\n",
+    "        \"amplitude\": drive_amplitude,\n",
+    "        \"frequency\": drive_frequency,\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we construct the resonator number operator to monitor its occupation and configure QuTiP's `SESolver` with the `CuVern7` integrator. We then call `solver.run` inside `CuQuantumBackend`, using scqubits' shared workstream."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial resonator occupation: 1.04974128e-05\n",
+      "Maximum resonator occupation: 0.307033729\n",
+      "Final resonator occupation: 0.307033729\n"
+     ]
+    }
+   ],
+   "source": [
+    "resonator_number = scq.identity_wrap(\n",
+    "    resonator.creation_operator() @ resonator.annihilation_operator(),\n",
+    "    resonator,\n",
+    "    hilbert_space.subsystem_list,\n",
+    "    use_cuquantum=True,\n",
+    ")\n",
+    "solver = qt.SESolver(\n",
+    "    driven_hamiltonian,\n",
+    "    options={\n",
+    "        \"method\": \"CuVern7\",\n",
+    "        \"atol\": 1e-8,\n",
+    "        \"rtol\": 1e-8,\n",
+    "        \"nsteps\": 10_000,\n",
+    "    },\n",
+    ")\n",
+    "workstream = scq.get_cuquantum_workstream()\n",
+    "\n",
+    "with qcu.CuQuantumBackend(workstream):\n",
+    "    result = solver.run(\n",
+    "        initial_state,\n",
+    "        tlist=times,\n",
+    "        e_ops=[resonator_number],\n",
+    "    )\n",
+    "\n",
+    "occupation = np.asarray(result.expect[0])\n",
+    "print(f\"Initial resonator occupation: {occupation[0]:.9g}\")\n",
+    "print(f\"Maximum resonator occupation: {occupation.max():.9g}\")\n",
+    "print(f\"Final resonator occupation: {occupation[-1]:.9g}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "nbsphinx": {
+   "execute": "never"
+  },
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/source/guide/settings/ipynb/custom_diagonalization.ipynb
+++ b/docs/source/guide/settings/ipynb/custom_diagonalization.ipynb
@@ -99,7 +99,9 @@
       "evals_cupy_sparse\n",
       "esys_cupy_sparse\n",
       "evals_jax_dense\n",
-      "esys_jax_dense\n"
+      "esys_jax_dense\n",
+      "esys_cuquantum\n",
+      "evals_cuquantum\n"
      ]
     }
    ],
@@ -559,7 +561,7 @@
    "source": [
     "## GPU support\n",
     "\n",
-    "Diagonalization on GPUs is currently supported through the [cupy](https://cupy.dev/), and optionally, the [jax](https://jax.readthedocs.io/en/latest/index.html) libraries. As already outlined above, to use user any of these packages for diagonalization, they have to be installed on the user's machine. \n",
+    "Diagonalization on GPUs is supported through the [cupy](https://cupy.dev/), [jax](https://jax.readthedocs.io/en/latest/index.html), and NVIDIA cuQuantum libraries. These optional packages must be installed before selecting their diagonalization methods. For cuQuantum dependencies, usage, and eigensolver settings, see [GPU acceleration with NVIDIA cuQuantum](../../hilbertspace/ipynb/cuquantum.ipynb).\n",
     "\n",
     "It is worth pointing out, that depending on one's hardware, and the quantum system studied, the performance of GPU vs CPU diagonalization may vary dramatically from setup to setup. \n",
     "\n",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,6 +100,7 @@ appropriately acknowledged by citing:
    :caption: COMPOSITE SYSTEMS
 
    ./guide/hilbertspace/ipynb/hilbertspace.ipynb
+   ./guide/hilbertspace/ipynb/cuquantum.ipynb
    ./guide/hilbertspace/ipynb/branch_analysis.ipynb
 
 


### PR DESCRIPTION
This PR adds documentation for the upcoming optional NVIDIA cuQuantum support in scqubits. The documentation is intended to be released alongside the corresponding scqubits features.

Main changes:

  - Added a new guide, GPU acceleration with NVIDIA cuQuantum 
  - Added the guide to the main documentation navigation, directly after the HilbertSpace guide.
  - Updated the custom-diagonalization notebook to list the cuQuantum eigensolvers and link to the new guide from its GPU-support section.
  - Documented the required NVIDIA GPU/CUDA environment and optional dependencies.
  - Explained workstream management, including:
      - automatic creation and reuse of the default scqubits workstream;
      - retrieving that workstream for compatible external usage;
      - registering an existing custom workstream before cuQuantum initialization
  - Added a complete fluxonium–resonator workflow covering:
      - construction of the composite system;
      - cuQuantum-backed Hamiltonian and drive operators;
      - low-energy eigensystem and branch analysis;
      - resonator charge-drive dynamics using qutip-cuquantum
  - Documented the eigensolver settings and limitations:
      - the Krylov settings and their defaults;
      - the maximum number of eigenvalues and eigenstates that can be requested
      - lookup generation requires bare-energy (BE) ordering and an explicit number of states